### PR TITLE
invalid byte sequence in GBK fix

### DIFF
--- a/lib/ar_to_ar.rb
+++ b/lib/ar_to_ar.rb
@@ -29,7 +29,7 @@ module ArToAr
     #class ModelName < ActiveRecord::Base
     def find_matched_line(file_path)
       File.open(file_path, "r++") do |file|
-        return file.find { |line| line.match /(class(.+)<\s*ActiveRecord::Base)/ }
+        return file.find { |line| line.force_encoding('UTF-8').match /(class(.+)<\s*ActiveRecord::Base)/ }
       end
     end
 


### PR DESCRIPTION
C:/Ruby22/lib/ruby/gems/2.2.0/gems/ar_to_ar-0.2.0/lib/ar_to_ar.rb:32:in `match': invalid byte sequence in GBK (ArgumentE
rror)
